### PR TITLE
feat: release 2.0.0

### DIFF
--- a/.res/info.txt
+++ b/.res/info.txt
@@ -22,7 +22,7 @@ srt://127.0.0.1:10014             # Liquidsoap (myradiosurround) SRT input port 
 srt://127.0.0.1:10015             # Liquidsoap (myradiosurround) SRT input port override_caller2
 srt://127.0.0.1:10016             # Liquidsoap (myradiosurround) SRT input port sat_sat1
 
-# Liquidsoap streamer (source-mystreamer)
+# Liquidsoap surround SRT streamer (source-mystreamersurround)
 http://127.0.0.1:9021/metrics     # Liquidsoap (myradiosurround) Prometheus Metrics
 http://127.0.0.1:7020/livesource  # Liquidsoap (myradiosurround) HTTP API
 
@@ -33,7 +33,7 @@ http://127.0.0.1:8000/myradio-midfi.aac          # Icecast mountpoint (AAC midfi
 http://127.0.0.1:8000/myradio-lofi.aac           # Icecast mountpoint (AAC lofi)
 http://127.0.0.1:8000/myradio-midfi.mp3          # Icecast mountpoint (MP3 midfi)
 http://127.0.0.1:8000/myradio-lofi.mp3           # Icecast mountpoint (MP3 lofi)
-http://127.0.0.1:8000/myradiosurround-hifi.aac   # Icecast mountpoint (AAC hifi surround)
+http://127.0.0.1:8000/myradiosurround-insane.aac # Icecast mountpoint (AAC insane 320kbps 5.1)
 
 # NGINX (HLS, only AAC audio)
 http://127.0.0.1:8080                             # Browse HLS files
@@ -41,7 +41,9 @@ http://127.0.0.1:8080/myradio/myradio.m3u8        # HLS playlist
 http://127.0.0.1:8080/myradio/myradio_hifi.m3u8   # HLS playlist (enforce hifi)
 http://127.0.0.1:8080/myradio/myradio_midfi.m3u8  # HLS playlist (enforce midfi)
 http://127.0.0.1:8080/myradio/myradio_lofi.m3u8   # HLS playlist (enforce lofi)
-http://127.0.0.1:8080/myradiosurround/myradiosurround_hifi.m3u8   # HLS playlist (enforce lofi)
+
+http://127.0.0.1:8080/myradiosurround/myradiosurround.m3u8          # HLS playlist
+http://127.0.0.1:8080/myradiosurround/myradiosurround_insane.m3u8   # HLS playlist (enforce insane profile)
 
 # Prometheus
 http://127.0.0.1:9090           # Prometheus web interface
@@ -53,4 +55,4 @@ http://127.0.0.1:3000           # Grafana web interface
 curl -s -d override_caller1 http://127.0.0.1:7000/livesource
 
 # Switch livesource for myradiosurround (please replace override_caller1 with anything you need)
-curl -s -d override_caller1 http://127.0.0.1:7010/livesource
+curl -s -d voieB_caller1 http://127.0.0.1:7010/livesource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,40 +1,64 @@
 # CHANGELOG.md
 
-## unreleased / no tag
+## 2.0.0 (2023-11-06)
 
 Features:
 
-- Add new dashboard for LUFS levels
-- Add new graphs in liquidsoap dashboard for SRT inputs, packet loss, drops...
-- improve README.md
-- Improve docker-compose.yml, Makefile and examples
-- Improve CHANGELOG.md
-- Add GREETINGS.md
+- split scripts for different liquidsoap usages, transcoder (to produce a radio
+  stream) and streamer (to send audio to a transcoder with SRT, and serve
+  playlists or network sources - WIP).
+- add surround profiles for 5.1 streaming.
+- add insane AAC quality profile (aac/fdk_aac lc 320kbps).
+- support disabling HLS or Icecast outputs completely (removing all qualities).
+- remove test file and use example configs by default for tests.
+- upgrade liquidsoap to v2.2.2
+- add new srtcaller containers in docker-compose.yml, one to stream local files
+  with ffmpeg, another one to stream a local playlist with liquidsoap and a m3u
+  file.
+
+Breaking changes:
+
+- Some variables have been renamed in the configuration file.
+- A new function must be declared in the configuration file to select a channel
+  layout (stereo or surround).
+- scripts paths have changed, be careful if you use the scripts folder directly.
+
+## 1.2.1 (2023-09-06)
+
+Features:
+
+- Add new dashboard for LUFS levels.
+- Add new graphs in liquidsoap dashboard for SRT inputs, packet loss, drops, etc.
+- improve README.md.
+- Improve docker-compose.yml, Makefile and examples.
+- Improve CHANGELOG.md.
+- Add GREETINGS.md.
+- upgrade liquidsoap to v2.2.1.
 
 ## 1.0.6 (2023-04-18)
 
 Features:
 
-- Add a prometheus metric to monitor LUFS levels of final radio stream
+- add a prometheus metric to monitor LUFS levels of final radio stream.
 
 ## 1.0.5 (2023-04-05)
 
 Bugfix:
 
-- Prevent freezes of the main loop protecting input sources with a buffer.
+- prevent freezes of the main loop protecting input sources with a buffer.
   We were experiencing icecast server restarts due to this issue.
 
 ## 1.0.4 (2023-03-17)
 
 Features:
 
-- add new SRT and input buffer metrics
-- add a Makefile
-- improve docker-compose.yml
+- add new SRT and input buffer metrics.
+- add a Makefile.
+- improve docker-compose.yml.
 
 # Known issues
 
-- Situations where SRT inputs get stuck with "No room to store incoming packets"
+- situations where SRT inputs get stuck with "No room to store incoming packets"
   when sources are flapping / restarting too fast / due to network errors.
 
 - SRT input buffers tend to get consumed faster than the source is able to

--- a/Makefile
+++ b/Makefile
@@ -12,18 +12,32 @@ artifact: ## Build binary artifact
 	@md5sum rf-liquidsoap-$(version).tar.gz
 
 test: ## Run test on the liquidsoap configuration
-	@docker compose up liquidsoap-test-transcoder liquidsoap-test-streamer
+	@docker compose up \
+		liquidsoap-test-transcoder-stereo \
+		liquidsoap-test-streamer-stereo \
+		liquidsoap-test-transcoder-surround \
+	  liquidsoap-test-streamer-surround
 
 reload: ## Update containers if needed and restart all liquidsoaps
 	@docker compose up -d
-	@docker compose restart liquidsoap-test-transcoder liquidsoap-test-streamer
-	@docker compose restart liquidsoap-myradio liquidsoap-myradiosurround source-mystreamer
+	@docker compose restart \
+		liquidsoap-test-transcoder-stereo \
+		liquidsoap-test-streamer-stereo \
+		liquidsoap-test-transcoder-surround \
+	  liquidsoap-test-streamer-surround
+	@docker compose restart \
+		liquidsoap-myradio \
+		liquidsoap-myradiosurround \
+		# source-mystreamer \
+		source-mystreamersurround \
 	@docker compose ps
 	@docker compose logs -f
 
-reload-streamer: ## Update containers if needed and restart source-mystreamer
+reload-streamers: ## Update containers if needed and restart source-mystreamersurround
 	@docker compose up -d
-	@docker compose restart source-mystreamer
+	@docker compose restart \
+		# source-mystreamer \
+		source-mystreamersurround
 	@docker compose ps
 	@docker compose logs -f
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,9 @@
 version: "3.3"
 services:
-  # Test validity of liquidsoap configurations
-  liquidsoap-test-transcoder:
-    command:
-    - -c
-    - /conf/myradio.liq
-    - /scripts/transcoder/00-live.liq
-    container_name: liquidsoap-test-transcoder
-    image: savonet/liquidsoap:rolling-release-v2.2.x
-    networks:
-    - default
-    volumes:
-    - ./example/liquidsoap/:/conf/:ro
-    - ./scripts/transcoder/:/scripts/transcoder/:ro
 
-  liquidsoap-test-streamer:
-    command:
-    - -c
-    - /conf/mystreamer.liq
-    - /scripts/streamer/00-live.liq
-    container_name: liquidsoap-test-streamer
-    image: savonet/liquidsoap:rolling-release-v2.2.x
-    networks:
-    - default
-    volumes:
-    - ./example/liquidsoap/:/conf/:ro
-    - ./scripts/streamer/:/scripts/streamer/:ro
+  ###############
+  # TRANSCODERS #
+  ###############
 
   # Run liquidsoap and create "myradio" stream
   liquidsoap-myradio:
@@ -78,7 +56,11 @@ services:
     - data_hls:/tmp/
     - data_liquidsoap:/state/
 
-  # Feed liquidsoap with an example SRT source (https://modular-station.com/)
+  ###############
+  # SRT SOURCES #
+  ###############
+
+  # Feed myradio with an example SRT source (https://modular-station.com/)
   source-voieA-caller1:
     command:
     - /usr/bin/ffmpeg
@@ -99,7 +81,7 @@ services:
     - default
     restart: unless-stopped
 
-  # Feed liquidsoap with an example SRT source (https://p-node.org/)
+  # Feed myradio with an example SRT source (https://p-node.org/)
   source-voieB-caller1:
     command:
     - /usr/bin/ffmpeg
@@ -120,7 +102,7 @@ services:
     - default
     restart: unless-stopped
 
-  # Feed liquidsoap with an example SRT source (https://datafruits.fm)
+  # Feed myradio with an example override SRT source (https://datafruits.fm)
   source-override-caller1:
     command:
     - /usr/bin/ffmpeg
@@ -141,26 +123,27 @@ services:
     - default
     restart: unless-stopped
 
-  # Feed liquidsoap with an example SRT source with liquidsoap (local playlist)
-  source-mystreamer:
+  # Feed myradiosurround with an example 5.1 SRT source with liquidsoap
+  # (local playlist)
+  source-mystreamersurround:
     command:
-    - /conf/mystreamer.liq
+    - /conf/mystreamersurround.liq
     - /scripts/streamer/00-live.liq
-    container_name: source-mystreamer
+    container_name: source-mystreamersurround
     image: savonet/liquidsoap:rolling-release-v2.2.x
     networks:
     - default
     restart: unless-stopped
     ports:
-    - 9021:9021/tcp
-    - 7020:7020/tcp
+    - 9031:9031/tcp
+    - 7030:7030/tcp
     volumes:
     - ./example/audio/:/audio/:ro
     - ./example/liquidsoap/:/conf/:ro
     - ./scripts/streamer/:/scripts/streamer/:ro
 
   # Feed liquidsoap with an example SRT source (local file)
-  source-surround:
+  source-ffmpegsurround:
     command:
     - /usr/bin/ffmpeg
     - -hide_banner
@@ -173,7 +156,7 @@ services:
     - -codec:a
     - pcm_s24le
     - "srt://liquidsoap-myradiosurround:10012" # voieB_caller1
-    container_name: source-surround
+    container_name: source-ffmpegsurround
     entrypoint: []
     image: savonet/liquidsoap:rolling-release-v2.2.x
     networks:
@@ -182,7 +165,11 @@ services:
     volumes:
     - ./example/audio/:/audio/:ro
 
-  # Streaming services: icecast
+  #####################
+  # STREAMING SERVERS #
+  #####################
+
+  # Icecast
   icecast:
     container_name: icecast
     environment:
@@ -198,7 +185,7 @@ services:
     ports:
     - 8000:8000
 
-  # Streaming services: hls (nginx)
+  # HLS (nginx)
   hls:
     container_name: hls
     expose:
@@ -213,7 +200,11 @@ services:
     - ./example/nginx/:/etc/nginx/conf.d/:ro
     - data_hls:/hls:ro
 
-  # Monitoring
+  ##############
+  # MONITORING #
+  ##############
+
+  # Dashboards
   grafana:
     container_name: grafana
     depends_on:
@@ -234,6 +225,8 @@ services:
     volumes:
     - ./example/grafana/provisioning:/etc/grafana/provisioning:ro
     - data_grafana:/var/lib/grafana
+
+  # Collector
   prometheus:
     command:
     - '--config.file=/etc/prometheus/prometheus.yml'
@@ -276,7 +269,7 @@ services:
   #   volumes:
   #   - ./example/alertmanager:/etc/alertmanager
 
-  # Container metrics
+  # Container / system metrics
   # cadvisor:
   #   container_name: cadvisor
   #   depends_on:
@@ -294,6 +287,63 @@ services:
   #   image: redis:latest
   #   ports:
   #   - 6379:6379
+
+  #########
+  # TESTS #
+  #########
+
+  # Test validity of liquidsoap configurations
+  liquidsoap-test-transcoder-stereo:
+    command:
+    - -c
+    - /conf/myradio.liq
+    - /scripts/transcoder/00-live.liq
+    container_name: liquidsoap-test-transcoder-stereo
+    image: savonet/liquidsoap:rolling-release-v2.2.x
+    networks:
+    - default
+    volumes:
+    - ./example/liquidsoap/:/conf/:ro
+    - ./scripts/transcoder/:/scripts/transcoder/:ro
+
+  liquidsoap-test-transcoder-surround:
+    command:
+    - -c
+    - /conf/myradiosurround.liq
+    - /scripts/transcoder/00-live.liq
+    container_name: liquidsoap-test-transcoder-surround
+    image: savonet/liquidsoap:rolling-release-v2.2.x
+    networks:
+    - default
+    volumes:
+    - ./example/liquidsoap/:/conf/:ro
+    - ./scripts/transcoder/:/scripts/transcoder/:ro
+
+  liquidsoap-test-streamer-stereo:
+    command:
+    - -c
+    - /conf/mystreamer.liq
+    - /scripts/streamer/00-live.liq
+    container_name: liquidsoap-test-streamer-stereo
+    image: savonet/liquidsoap:rolling-release-v2.2.x
+    networks:
+    - default
+    volumes:
+    - ./example/liquidsoap/:/conf/:ro
+    - ./scripts/streamer/:/scripts/streamer/:ro
+
+  liquidsoap-test-streamer-surround:
+    command:
+    - -c
+    - /conf/mystreamersurround.liq
+    - /scripts/streamer/00-live.liq
+    container_name: liquidsoap-test-streamer-surround
+    image: savonet/liquidsoap:rolling-release-v2.2.x
+    networks:
+    - default
+    volumes:
+    - ./example/liquidsoap/:/conf/:ro
+    - ./scripts/streamer/:/scripts/streamer/:ro
 
 volumes:
   data_grafana: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     - /conf/myradio.liq
     - /scripts/transcoder/00-live.liq
     container_name: liquidsoap-myradio
-    image: savonet/liquidsoap:rolling-release-v2.2.x
+    image: savonet/liquidsoap:v2.2.2
     networks:
     - default
     restart: unless-stopped
@@ -36,7 +36,7 @@ services:
     - /conf/myradiosurround.liq
     - /scripts/transcoder/00-live.liq
     container_name: liquidsoap-myradiosurround
-    image: savonet/liquidsoap:rolling-release-v2.2.x
+    image: savonet/liquidsoap:v2.2.2
     networks:
     - default
     restart: unless-stopped
@@ -76,7 +76,7 @@ services:
     - "srt://liquidsoap-myradio:10000" # voieA_caller1
     container_name: source-voieA-caller1
     entrypoint: []
-    image: savonet/liquidsoap:rolling-release-v2.2.x
+    image: savonet/liquidsoap:v2.2.2
     networks:
     - default
     restart: unless-stopped
@@ -97,7 +97,7 @@ services:
     - "srt://liquidsoap-myradio:10002" # voieB_caller1
     container_name: source-voieB-caller1
     entrypoint: []
-    image: savonet/liquidsoap:rolling-release-v2.2.x
+    image: savonet/liquidsoap:v2.2.2
     networks:
     - default
     restart: unless-stopped
@@ -118,7 +118,7 @@ services:
     - "srt://liquidsoap-myradio:10004" # override_caller1
     container_name: source-override-caller1
     entrypoint: []
-    image: savonet/liquidsoap:rolling-release-v2.2.x
+    image: savonet/liquidsoap:v2.2.2
     networks:
     - default
     restart: unless-stopped
@@ -130,7 +130,7 @@ services:
     - /conf/mystreamersurround.liq
     - /scripts/streamer/00-live.liq
     container_name: source-mystreamersurround
-    image: savonet/liquidsoap:rolling-release-v2.2.x
+    image: savonet/liquidsoap:v2.2.2
     networks:
     - default
     restart: unless-stopped
@@ -158,7 +158,7 @@ services:
     - "srt://liquidsoap-myradiosurround:10012" # voieB_caller1
     container_name: source-ffmpegsurround
     entrypoint: []
-    image: savonet/liquidsoap:rolling-release-v2.2.x
+    image: savonet/liquidsoap:v2.2.2
     networks:
     - default
     restart: unless-stopped
@@ -299,7 +299,7 @@ services:
     - /conf/myradio.liq
     - /scripts/transcoder/00-live.liq
     container_name: liquidsoap-test-transcoder-stereo
-    image: savonet/liquidsoap:rolling-release-v2.2.x
+    image: savonet/liquidsoap:v2.2.2
     networks:
     - default
     volumes:
@@ -312,7 +312,7 @@ services:
     - /conf/myradiosurround.liq
     - /scripts/transcoder/00-live.liq
     container_name: liquidsoap-test-transcoder-surround
-    image: savonet/liquidsoap:rolling-release-v2.2.x
+    image: savonet/liquidsoap:v2.2.2
     networks:
     - default
     volumes:
@@ -325,7 +325,7 @@ services:
     - /conf/mystreamer.liq
     - /scripts/streamer/00-live.liq
     container_name: liquidsoap-test-streamer-stereo
-    image: savonet/liquidsoap:rolling-release-v2.2.x
+    image: savonet/liquidsoap:v2.2.2
     networks:
     - default
     volumes:
@@ -338,7 +338,7 @@ services:
     - /conf/mystreamersurround.liq
     - /scripts/streamer/00-live.liq
     container_name: liquidsoap-test-streamer-surround
-    image: savonet/liquidsoap:rolling-release-v2.2.x
+    image: savonet/liquidsoap:v2.2.2
     networks:
     - default
     volumes:

--- a/example/liquidsoap/mystreamer.liq
+++ b/example/liquidsoap/mystreamer.liq
@@ -1,7 +1,7 @@
 streamer_name = "mystreamer"
 
 # Radio settings
-formats_picker = fun (formats) -> formats.stereo
+formats_picker = fun (formats) -> formats.flac.stereo
 harbor_http_port = 7020
 prometheus_server_port = 9021
 liquidsoap_log_level = 3
@@ -10,5 +10,5 @@ liquidsoap_log_level = 3
 input_playlist_file = "/audio/lib/#{streamer_name}.m3u"
 
 # SRT output configuration
-srt_host = "liquidsoap-myradiosurround"
-srt_port = 10010
+srt_host = "liquidsoap-myradio"
+srt_port = 10005 # override_caller2

--- a/example/liquidsoap/mystreamersurround.liq
+++ b/example/liquidsoap/mystreamersurround.liq
@@ -11,4 +11,4 @@ input_playlist_file = "/audio/lib/#{streamer_name}.m3u"
 
 # SRT output configuration
 srt_host = "liquidsoap-myradiosurround"
-srt_port = 10010
+srt_port = 10010 # voieA_caller1


### PR DESCRIPTION
Waiting for liquidsoap release to update docker-compose liquidsoap versions

Features:

- split scripts for different liquidsoap usages, transcoder (to produce a radio
  stream) and streamer (to send audio to a transcoder with SRT, and serve
  playlists or network sources - WIP).
- add surround profiles for 5.1 streaming.
- add insane AAC quality profile (AAC/FDK_AAC LC 320kbps).
- support disabling HLS or Icecast outputs completely (removing all qualities).
- remove test file and use example configs by default for tests.
- update to liquidsoap v2.2.2
- add new srtcaller containers in docker-compose.yml, one to stream local files
  with ffmpeg, another one to stream a local playlist with liquidsoap and a m3u
  file.

Breaking changes:

- Some variables have been renamed in the configuration file.
- A new function must be declared in the configuration file to select a channel
  layout (stereo or surround).
- scripts paths have changed, be careful if you use the scripts folder directly.