### PR TITLE
Assign named clocks.

### DIFF
--- a/scripts/transcoder/00-live.liq
+++ b/scripts/transcoder/00-live.liq
@@ -163,6 +163,9 @@ set_metric_audio_lufs =
 
 radio_prod = lufs(window=5., radio_prod)
 
+# Assign a named clock for visibility.
+clock.assign_new(id="radio_prod", [radio_prod])
+
 thread.run(every=5., {set_metric_audio_lufs(radio_prod.lufs())})
 
 %include "80-outputs.liq"

--- a/scripts/transcoder/60-core.liq
+++ b/scripts/transcoder/60-core.liq
@@ -13,6 +13,9 @@ end
 def mk_source(s) =
   srt_input = input.srt(id=(s.name : string), max=3.0, port=s.port)
 
+  # Assign a named clock.
+  clock.assign_new(id=s.name, [srt_input])
+
   # Create the several latency time series for this input
   latency_metrics_create(label_values=[radio_name, "input", s.name], srt_input)
 


### PR DESCRIPTION
This is useful for debugging as it assigns a name to the clocks that is easier to track later in the logs/metrics.