### PR TITLE
Drop use of latency metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,16 +274,7 @@ scripts.
 | Name                                        | Type    | Description                            |
 |-------------------------------------------- | ------- | -------------------------------------- |
 | liquidsoap_hlssegment_sent                  | counter | Number of HLS segment send to segment-forwarder |
-| liquidsoap_input_latency_seconds            | gauge   | Mean input latency over the chosen window |
-| liquidsoap_input_max_latency_seconds        | gauge   | Max input latency since start |
-| liquidsoap_input_peak_latency_seconds       | gauge   | Peak input latency over the chosen window |
-| liquidsoap_output_latency_seconds           | gauge   | Mean output latency over the chosen window |
 | liquidsoap_output_lufs_5s                   | gauge   | Audio LUFS Analysis of radio_prod with 5s windows |
-| liquidsoap_output_max_latency_seconds       | gauge   | Max output latency since start |
-| liquidsoap_output_peak_latency_seconds      | gauge   | Peak output latency over the chosen window |
-| liquidsoap_overall_latency_seconds          | gauge   | Mean overall latency over the chosen window |
-| liquidsoap_overall_max_latency_seconds      | gauge   | Max overall latency since start |
-| liquidsoap_overall_peak_latency_seconds     | gauge   | Peak overall latency over the chosen window |
 | liquidsoap_source_is_blank                  | gauge   | Is source blank? (no audio) |
 | liquidsoap_source_is_playing                | gauge   | Is source playing? |
 | liquidsoap_source_is_preferred_livesource   | gauge   | Is source the preferred livesource? |

--- a/scripts/transcoder/00-live.liq
+++ b/scripts/transcoder/00-live.liq
@@ -64,11 +64,6 @@ radio_prod =
     ]
   )
 
-# Create the several latency time series for the output
-latency_metrics_create(
-  label_values=[radio_name, "output", "radio_prod"], radio_prod
-)
-
 # Create is_ready and duration_unready_seconds time series for the output and
 # update them recurrently.
 is_ready_metric_set =

--- a/scripts/transcoder/20-prometheus.liq
+++ b/scripts/transcoder/20-prometheus.liq
@@ -5,11 +5,6 @@
 # We define here "_metric_create" functions which must be used with
 # more parameters to create new Time Series
 
-# latency metrics are internal latencies automatically generated from
-# a liquidsoap source.
-# cf. https://github.com/savonet/liquidsoap/blob/36e219a7105f6b260fcdb3c4234a6b9baa19af76/doc/content/prometheus.md#prometheuslatency
-latency_metrics_create = prometheus.latency(labels=["radio", "type", "name"])
-
 # "is_ready" is a metric which give the status of given liquidsoap
 # source at a given time.
 # "duration_unready_seconds" is a counter of the time the source is

--- a/scripts/transcoder/60-core.liq
+++ b/scripts/transcoder/60-core.liq
@@ -16,9 +16,6 @@ def mk_source(s) =
   # Assign a named clock.
   clock.assign_new(id=s.name, [srt_input])
 
-  # Create the several latency time series for this input
-  latency_metrics_create(label_values=[radio_name, "input", s.name], srt_input)
-
   # Create is_ready and duration_unready_seconds time series for this input and
   # update them recurrently.
   is_ready_metric_set =


### PR DESCRIPTION
Latency metrics are consuming quite a good number of CPU cycles and I don't think that they were ever used. If so, we should drop them.