### PR TITLE
fix(settings): keep one fast queue to protect clocked threads

### DIFF
--- a/scripts/transcoder/10-settings.liq
+++ b/scripts/transcoder/10-settings.liq
@@ -30,4 +30,4 @@ preferred_live_source = ref(list.nth(input_list, 0).name)
 # Queues
 settings.scheduler.non_blocking_queues := 0
 settings.scheduler.generic_queues := 1
-settings.scheduler.fast_queues := 0
+settings.scheduler.fast_queues := 1


### PR DESCRIPTION
We need at least one queue to preserve clocked threads behavior (with `every=1.,`)