### PR TITLE
Set interleaved to false.

### DIFF
--- a/scripts/transcoder/formats/hls.aac.liq
+++ b/scripts/transcoder/formats/hls.aac.liq
@@ -2,8 +2,11 @@ let formats.stereo.hls.aac =
   [
     (
       "lofi",
+
+      # See: https://github.com/savonet/liquidsoap/pull/4401
       %ffmpeg(
         format = "mpegts",
+        interleaved = false,
         %audio(
           codec = "aac",
           channels = 2,
@@ -17,6 +20,7 @@ let formats.stereo.hls.aac =
       "midfi",
       %ffmpeg(
         format = "mpegts",
+        interleaved = false,
         %audio(
           codec = "aac",
           channels = 2,
@@ -30,6 +34,7 @@ let formats.stereo.hls.aac =
       "hifi",
       %ffmpeg(
         format = "mpegts",
+        interleaved = false,
         %audio(
           codec = "aac",
           channels = 2,
@@ -43,6 +48,7 @@ let formats.stereo.hls.aac =
       "insane",
       %ffmpeg(
         format = "mpegts",
+        interleaved = false,
         %audio(
           codec = "aac",
           channels = 2,
@@ -60,6 +66,7 @@ let formats.surround.hls.aac =
       "hifi",
       %ffmpeg(
         format = "mpegts",
+        interleaved = false,
         %audio(
           codec = "aac",
           channel_layout = 5.1,
@@ -73,6 +80,7 @@ let formats.surround.hls.aac =
       "insane",
       %ffmpeg(
         format = "mpegts",
+        interleaved = false,
         %audio(
           codec = "aac",
           channel_layout = 5.1,

--- a/scripts/transcoder/formats/hls.libfdk_aac.liq
+++ b/scripts/transcoder/formats/hls.libfdk_aac.liq
@@ -2,8 +2,11 @@ let formats.stereo.hls.libfdk_aac =
   [
     (
       "lofi",
+
+      # See: https://github.com/savonet/liquidsoap/pull/4401
       %ffmpeg(
         format = "mpegts",
+        interleaved = false,
         %audio(
           codec = "libfdk_aac",
           channels = 2,
@@ -18,6 +21,7 @@ let formats.stereo.hls.libfdk_aac =
       "midfi",
       %ffmpeg(
         format = "mpegts",
+        interleaved = false,
         %audio(
           codec = "libfdk_aac",
           channels = 2,
@@ -32,6 +36,7 @@ let formats.stereo.hls.libfdk_aac =
       "hifi",
       %ffmpeg(
         format = "mpegts",
+        interleaved = false,
         %audio(
           codec = "libfdk_aac",
           channels = 2,
@@ -46,6 +51,7 @@ let formats.stereo.hls.libfdk_aac =
       "insane",
       %ffmpeg(
         format = "mpegts",
+        interleaved = false,
         %audio(
           codec = "libfdk_aac",
           channels = 2,
@@ -64,6 +70,7 @@ let formats.surround.hls.libfdk_aac =
       "hifi",
       %ffmpeg(
         format = "mpegts",
+        interleaved = false,
         %audio(
           codec = "libfdk_aac",
           channel_layout = 5.1,
@@ -78,6 +85,7 @@ let formats.surround.hls.libfdk_aac =
       "insane",
       %ffmpeg(
         format = "mpegts",
+        interleaved = false,
         %audio(
           codec = "libfdk_aac",
           channel_layout = 5.1,


### PR DESCRIPTION
This PR fixes a bug in the HLS encoder that results in the segments being off by one: first segment is empty, second segment has first segment's content and etc.

See: https://github.com/savonet/liquidsoap/pull/4401 for details.