### PR TITLE
Directly name clocks.

### DIFF
--- a/scripts/transcoder/00-live.liq
+++ b/scripts/transcoder/00-live.liq
@@ -159,7 +159,7 @@ set_metric_audio_lufs =
 radio_prod = lufs(window=5., radio_prod)
 
 # Assign a named clock for visibility.
-clock.assign_new(id="radio_prod", [radio_prod])
+clock(radio_prod.clock).id := "radio_prod"
 
 thread.run(every=5., {set_metric_audio_lufs(radio_prod.lufs())})
 

--- a/scripts/transcoder/60-core.liq
+++ b/scripts/transcoder/60-core.liq
@@ -14,7 +14,7 @@ def mk_source(s) =
   srt_input = input.srt(id=(s.name : string), max=3.0, port=s.port)
 
   # Assign a named clock.
-  clock.assign_new(id=s.name, [srt_input])
+  clock(srt_input.clock).id := s.name
 
   # Create is_ready and duration_unready_seconds time series for this input and
   # update them recurrently.

--- a/scripts/transcoder/outputs/icecast.liq
+++ b/scripts/transcoder/outputs/icecast.liq
@@ -18,7 +18,7 @@ def mk_output(source, file_extension, quality, encoder) =
 
   # Assign a unique id to the new clock
   id = "icecast_#{quality}#{file_extension}"
-  clock.assign_new(id=id, [source])
+  clock(source.clock).id := id
 
   output.icecast(
     id=id,


### PR DESCRIPTION
This PR assigns a clock name instead of creating a new clock on waiting on unification. Shouldn't fix any bug but is a more natural and direct way of doing what want to do.