### PR TITLE
Cleanup top-level variable overrides.

### DIFF
--- a/scripts/streamer/90-http.liq
+++ b/scripts/streamer/90-http.liq
@@ -5,7 +5,7 @@ def get_readiness(_, response) =
   response.status_code(200)
 end
 
-def flatten_meta(metadata) =
+def flatten_meta(m) =
   j = json()
   list.iter(
     fun (m) ->
@@ -13,14 +13,14 @@ def flatten_meta(metadata) =
         let (key, value) = m
         j.add(key, value)
       end,
-    metadata ?? []
+    m ?? []
   )
   j
 end
 
 ## GET /playlist
-def get_playlist(_, response) =
-  response.json(
+def get_playlist(_, res) =
+  res.json(
     {
       current_track=flatten_meta(radio.last_metadata()),
       current_track_remaining=radio.remaining(),
@@ -30,15 +30,15 @@ def get_playlist(_, response) =
 end
 
 ## POST /playlist
-def post_playlist(request, response) =
-  method = request.body()
+def post_playlist(req, res) =
+  method = req.body()
   if
     list.exists(fun (s) -> s == method, ["skip"])
   then
     radio.skip()
-    response.status_code(200)
+    res.status_code(200)
   else
-    response.status_code(400)
+    res.status_code(400)
   end
 end
 

--- a/scripts/transcoder/00-live.liq
+++ b/scripts/transcoder/00-live.liq
@@ -91,8 +91,8 @@ thread.run(
 )
 
 # Update is_playing metrics at each metadata change
-def update_is_playing_metrics(metadata) =
-  source_tag = list.assoc(default="", "source_tag", metadata)
+def update_is_playing_metrics(m) =
+  source_tag = list.assoc(default="", "source_tag", m)
 
   def update_metric(s) =
     if

--- a/scripts/transcoder/90-http.liq
+++ b/scripts/transcoder/90-http.liq
@@ -18,13 +18,13 @@ def get_livesource(_, response) =
 end
 
 ## POST /livesource
-def post_livesource(request, response) =
-  data = request.body()
+def post_livesource(req, res) =
+  data = req.body()
   if
     not list.exists(fun (s) -> s.name == data, input_sources)
   then
-    response.status_code(400)
-    response.json(
+    res.status_code(400)
+    res.json(
       {
         error_message=
           "input #{data} does not exist"
@@ -37,7 +37,7 @@ def post_livesource(request, response) =
     ignore(
       file.write(data=data, append=false, perms=0o644, livesource_state_path)
     )
-    response.json({preferred_output=data})
+    res.json({preferred_output=data})
   end
 end
 

--- a/scripts/transcoder/outputs/hls.liq
+++ b/scripts/transcoder/outputs/hls.liq
@@ -46,13 +46,20 @@ end
 ## HLS segments
 
 def segment_name(metadata) =
-  let {position, duration, extname, stream_name} = metadata
-  segment_duration = int_of_float(duration)
+  let {
+    position = segment_position,
+    duration = segment_duration,
+    extname,
+    stream_name
+  } = metadata
+  segment_duration = int_of_float(segment_duration)
   segment_timestamp = int_of_float(time())
 
   # Add the codec to the segment name because it's expected by segment-forwarder
   segment_prefix = string.replace(pattern="_", fun (_) -> "_aac_", stream_name)
-  "#{segment_prefix}_#{segment_duration}_#{position}_#{segment_timestamp}.ts"
+  "#{segment_prefix}_#{segment_duration}_#{segment_position}_#{
+    segment_timestamp
+  }.ts"
 end
 
 def on_file_change(~state, fname) =
@@ -70,11 +77,11 @@ def on_file_change(~state, fname) =
           log.info(
             "Uploading #{fname} to #{target}/#{path.basename(fname)}"
           )
-          file = file.contents(fname)
+          data = file.contents(fname)
           uploadsegment =
             http.post(
               headers=[("Origin", hls_segments_http_post_origin)],
-              data=file,
+              data=data,
               timeout=2.,
               target ^ "/#{path.basename(fname)}"
             )
@@ -130,7 +137,7 @@ end
 # HLS outputs don't have any restriction with clock
 # so we can leave them in the same clock as radio_prod
 
-def mk_hls_output(selected_formats, source) =
+def mk_hls_output(selected_formats, s) =
   def mk_format(name) =
     ("#{radio_name}_#{name}", list.assoc(name, available_hls_formats))
   end
@@ -149,6 +156,6 @@ def mk_hls_output(selected_formats, source) =
     segment_name=segment_name,
     hls_segments_directory,
     list.map(mk_format, selected_formats),
-    source
+    s
   )
 end

--- a/scripts/transcoder/outputs/icecast.liq
+++ b/scripts/transcoder/outputs/icecast.liq
@@ -11,14 +11,14 @@ icecast_aac_encoder =
 available_icecast_formats =
   [("aac", icecast_aac_encoder), ("mp3", formats.icecast.mp3)]
 
-def mk_output(source, file_extension, quality, encoder) =
+def mk_output(s, file_extension, quality, enc) =
   # Wrap the source in a buffer to avoid blocking the whole
   # streaming thread when icecast is down
-  source = buffer(source)
+  s = buffer(s)
 
   # Assign a unique id to the new clock
   id = "icecast_#{quality}#{file_extension}"
-  clock(source.clock).id := id
+  clock(s.clock).id := id
 
   output.icecast(
     id=id,
@@ -29,12 +29,12 @@ def mk_output(source, file_extension, quality, encoder) =
     send_icy_metadata=false,
     password=icecast_password,
     mount="#{radio_name}-#{quality}#{file_extension}",
-    encoder,
-    source
+    enc,
+    s
   )
 end
 
-def mk_icecast_outputs(selected_formats, source) =
+def mk_icecast_outputs(selected_formats, s) =
   list.iter(
     fun (selected_format) ->
       begin
@@ -44,10 +44,8 @@ def mk_icecast_outputs(selected_formats, source) =
         list.iter(
           fun (selected_sub_format) ->
             begin
-              encoder = list.assoc(selected_sub_format, format.sub_formats)
-              mk_output(
-                source, format.file_extension, selected_sub_format, encoder
-              )
+              enc = list.assoc(selected_sub_format, format.sub_formats)
+              mk_output(s, format.file_extension, selected_sub_format, enc)
             end,
           selected_sub_formats
         )


### PR DESCRIPTION
This PR uses the warning from `2.4.x` to cleanup top-level variable overrides.

It can be merged right and works with release `2.3.3`.