### PR TITLE
feat(CI): add PR pre-release artifacts

### DIFF
--- a/.github/PR-RELEASE-README.md
+++ b/.github/PR-RELEASE-README.md
@@ -1,0 +1,24 @@
+PR Pre-release workflow — quick usage
+
+What this does
+- Builds artifacts for a PR using `make artifact VERSION=...` and creates/updates a draft prerelease attached to the PR.
+
+How to trigger
+- Automatic: the workflow triggers on `pull_request` (opened, reopened, synchronize).
+- Manual: from the Actions UI choose "PR Pre-release" and use `workflow_dispatch` inputs:
+  - `pr_number` (required): target PR number
+  - `force_version` (optional): override the computed version, e.g. `v1.2.3`
+
+Outputs and usage
+- The workflow attaches a zip and an md5 into a draft prerelease (GitHub Releases).
+- A comment is posted to the PR with the release link and an example snippet to use in `docker-compose`:
+
+  LIQUIDSOAP_REF=<release-tag>
+
+Local testing
+- To produce the artifact locally run from repo root:
+
+```bash
+make artifact VERSION=v0.0.0-test
+ls -la dist/
+```

--- a/.github/workflows/pr-pre-release.yml
+++ b/.github/workflows/pr-pre-release.yml
@@ -1,0 +1,47 @@
+name: PR Pre-Release
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Target PR number (required for manual trigger)"
+        required: true
+
+jobs:
+  pr-pre-release:
+    name: PR Pre-Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Build artifacts via Makefile
+        run: |
+          mkdir -p dist
+          make artifact VERSION="pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}"
+          ls -la dist
+      - name: Create or update a draft pre-release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          name: "[Pre-release] ${{ github.event.pull_request.title }}"
+          body: |
+            Pre-release for PR #${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          draft: true
+          prerelease: true
+          files: |
+            dist/*.zip
+            dist/*.md5
+      - name: Post or update PR comment with release link
+        if: github.event_name == 'pull_request' || github.event.inputs.pr_number != ''
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          edit-mode: replace
+          body: |
+            Pre-release for PR #${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+            Download the artifacts from [here](https://github.com/radiofrance/rf-liquidsoap/releases).

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ help: ## Display this message
 	@grep -E '(^[a-zA-Z0-9_.-]+:.*?##.*$$)|(^##)' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}' | sed -e 's/\[32m##/[33m/'
 
 version = $(shell git describe --tags --long)
+VERSION ?= $(shell git describe --tags --long 2>/dev/null || echo "v0.0.0")
+DIST_DIR := dist
 
 install:
 	@npm install -g liquidsoap-prettier@v1.8.3
@@ -10,12 +12,19 @@ install:
 fmt: ## Format liquidsoap scripts
 	@find . -type f -name '*.liq' -exec liquidsoap-prettier -w {} \;
 
-artifact: ## Build binary artifact
-	@mkdir /tmp/rf-liquidsoap-$(version)
-	@cp -r scripts/ /tmp/rf-liquidsoap-$(version)/
-	@tar --exclude-vcs --owner=0 --group=0 -C /tmp -cvzf rf-liquidsoap-$(version).tar.gz rf-liquidsoap-$(version)/
-	@rm -rf /tmp/rf-liquidsoap-$(version)/
-	@md5sum rf-liquidsoap-$(version).tar.gz
+artifact: ## Build binary artifact (zip + md5 in dist/)
+	@set -eu; \
+	mkdir -p $(DIST_DIR); \
+	TMPDIR=$$(mktemp -d /tmp/rf-liquidsoap-XXXX); \
+	cp -r scripts/ "$${TMPDIR}/rf-liquidsoap/"; \
+	cd "$${TMPDIR}" && zip -qr "$(CURDIR)/$(DIST_DIR)/rf-liquidsoap-$(VERSION).zip" rf-liquidsoap; \
+	rm -rf "$${TMPDIR}"; \
+	if command -v md5 >/dev/null 2>&1; then \
+		md5 -q "$(CURDIR)/$(DIST_DIR)/rf-liquidsoap-$(VERSION).zip" > "$(CURDIR)/$(DIST_DIR)/rf-liquidsoap-$(VERSION).zip.md5"; \
+	else \
+		md5sum "$(CURDIR)/$(DIST_DIR)/rf-liquidsoap-$(VERSION).zip" | awk '{print $$1}' > "$(CURDIR)/$(DIST_DIR)/rf-liquidsoap-$(VERSION).zip.md5"; \
+	fi; \
+	ls -la $(CURDIR)/$(DIST_DIR)
 
 test: ## Run test on the liquidsoap configuration
 	@docker compose up \


### PR DESCRIPTION
Introducing a new Actions workflow for building and attaching pre-release artifacts to pull requests.

- Added a GitHub Actions workflow (`.github/workflows/pr-pre-release.yml`) that automatically builds artifacts for each pull request, attaches them to a draft pre-release, and posts a comment with download instructions in the PR. This workflow can also be triggered manually with a specific PR number as input.
- Refactored the `artifact` target in the `Makefile` to output artifacts as zip files (with md5 checksums) in a dedicated `dist/` directory.

BEGIN_COMMIT_OVERRIDE
feat(CI): add PR pre-release artifacts
END_COMMIT_OVERRIDE